### PR TITLE
rock: sepolicy: remove redundant entries from file_contexts

### DIFF
--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -1,6 +1,3 @@
-# Firmware Partition
-/dev/0:0:0:49476                                                                                            u:object_r:teei_rpmb_device:s0
-
 # Power
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power-service\.pixel-libperfmgr                           u:object_r:hal_power_default_exec:s0
 
@@ -51,5 +48,4 @@
 /(vendor|system/vendor)/bin/hw/android\.hardware\.sensors-service\.xiaomi-multihal                          u:object_r:hal_sensors_default_exec:s0
 
 # NFC
-/dev/nq-nci                                                                                                 u:object_r:nfc_device:s0
 /dev/ttyACM1                                                                                                u:object_r:nfc_device:s0


### PR DESCRIPTION
/dev/nq-nci and /dev/0:0:0:49476 are already handled in device/mediatek/sepolicy_vndr which causes build to fail